### PR TITLE
Update product fetching logic to support 'all' type in API and UI

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -296,14 +296,17 @@ export function registerApiRoutes(app, adminDb) {
       let list = [];
 
       if (rawType === 'all') {
-        // Combine Indian and Imported product lists into a single "all" view
+        // Combine Indian and Imported product lists into a single "all" view.
+        // Tag each entry with its source type so the UI can show a pill.
         const [indDoc, impDoc] = await Promise.all([
           adminDb.collection('products_by_type').doc('indian').get(),
           adminDb.collection('products_by_type').doc('imported').get(),
         ]);
         const indList = indDoc.exists ? (indDoc.data().items || []) : [];
         const impList = impDoc.exists ? (impDoc.data().items || []) : [];
-        list = [...indList, ...impList];
+        const taggedInd = indList.map((it) => ({ ...it, _srcType: 'indian' }));
+        const taggedImp = impList.map((it) => ({ ...it, _srcType: 'imported' }));
+        list = [...taggedInd, ...taggedImp];
         type = 'all';
       } else {
         const doc = await adminDb.collection('products_by_type').doc(type).get();
@@ -334,7 +337,8 @@ export function registerApiRoutes(app, adminDb) {
         const description = (pd.description || '').toString();
         const sizes = Array.isArray(pd.sizes) ? pd.sizes : [];
         const pcs_per_set = Number(pd.pcs_per_set || 0) || 0;
-        items.push({ content_id: sku, title, price, currency, image_url, description, sizes, pcs_per_set });
+        const source_type = (it._srcType || type || '').toString();
+        items.push({ content_id: sku, title, price, currency, image_url, description, sizes, pcs_per_set, source_type });
       }
 
       return res.status(200).json({ ok: true, type, page: p, pageSize, total, pageCount, items });

--- a/web/src/app/components/ProductCard.tsx
+++ b/web/src/app/components/ProductCard.tsx
@@ -10,6 +10,7 @@ export type Product = {
   image_url?: string;
   description?: string;
   sizes?: string[];
+   source_type?: string;
 };
 
 export type ProductCardProps = {
@@ -18,9 +19,10 @@ export type ProductCardProps = {
   onAddToCart: (product: Product, size: string, qty: number) => void;
   onViewImages: (content_id: string) => void;
   onGoToCart: () => void;
+  showTypePill?: boolean;
 };
 
-export default function ProductCard({ product, formatCurrency, onAddToCart, onViewImages, onGoToCart }: ProductCardProps) {
+export default function ProductCard({ product, formatCurrency, onAddToCart, onViewImages, onGoToCart, showTypePill }: ProductCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [selectedSize, setSelectedSize] = useState("");
   const [qty, setQty] = useState(1);
@@ -83,7 +85,24 @@ export default function ProductCard({ product, formatCurrency, onAddToCart, onVi
           />
         </div>
       )}
-      <div style={{ fontWeight: 600, fontSize: 14 }}>{product.title}</div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 6 }}>
+        <div style={{ fontWeight: 600, fontSize: 14, flex: 1, minWidth: 0 }}>{product.title}</div>
+        {showTypePill && product.source_type && (
+          <div
+            style={{
+              fontSize: 10,
+              padding: "2px 8px",
+              borderRadius: 999,
+              border: `1px solid ${product.source_type === "imported" ? "#2563eb" : "#16a34a"}`,
+              background: product.source_type === "imported" ? "rgba(37,99,235,0.16)" : "rgba(22,163,74,0.16)",
+              color: product.source_type === "imported" ? "#93c5fd" : "#bbf7d0",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {product.source_type === "imported" ? "Imported" : "Indian"}
+          </div>
+        )}
+      </div>
       {product.description && (
         <div
           style={{

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -33,6 +33,7 @@ type Product = {
   image_url?: string;
   description?: string;
   sizes?: string[];
+  source_type?: string;
 };
 
 export default function Page() {
@@ -451,6 +452,7 @@ export default function Page() {
                     formatCurrency={formatCurrency}
                     onAddToCart={onAddProductSized}
                     onViewImages={openGallery}
+                    showTypePill={browseType === "all"}
                     onGoToCart={() => {
                       try {
                         const el = document.getElementById("cart");


### PR DESCRIPTION
- Modified the API to allow fetching products of type 'all', combining both 'indian' and 'imported' product lists.
- Updated the frontend to include a new button for selecting 'all' products, enhancing user browsing options.
- Adjusted state management to accommodate the new 'all' type in product fetching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an 'all' products view merging Indian and Imported, returns source_type from the API, and updates the UI with an All filter and source-type pill.
> 
> - **Backend**
>   - `GET /api/products`:
>     - Support `type=all` by fetching `products_by_type/indian` and `.../imported` in parallel, tagging items and merging lists.
>     - Include `source_type` in each returned item.
>     - Preserve pagination; accept optional `pageSize`.
> - **Frontend**
>   - Browsing:
>     - Add "All" filter (default) alongside Indian/Imported; when "All" is selected, request with `pageSize=15`.
>   - Product model/UI:
>     - Extend `Product` with `source_type`.
>     - `ProductCard`: new `showTypePill` prop; display a colored pill for Imported/Indian when browsing "All".
>     - Pass `showTypePill` from `page.tsx` when `browseType === "all"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67c1d176e33eff14a792de6d7fc5304572713060. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->